### PR TITLE
explicitly specify supervisord config

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -38,4 +38,4 @@ cp $TEMPLATE $CONFIGFILE
 
 echo "Using configuration file:"
 cat $CONFIGFILE
-exec supervisord -n
+exec supervisord -n -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
Removes warning:

UserWarning: Supervisord is running as root and it is searching for its
configuration file in default locations (including its current working
directory); you probably want to specify a "-c" argument specifying an
absolute path to a configuration file for improved security.
